### PR TITLE
Annotate clojang.jinterface.otp.messaging

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
                    :unit        :unit
                    :system      :system
                    :integration :integration
-                   :type        :type}
+                   :typed       :typed}
   :codox          {:output-path "docs/master/current"
                    :doc-paths   ["docs/source"]
                    :metadata    {:doc/format :markdown}}

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,8 @@
   :test-selectors {:default     :unit
                    :unit        :unit
                    :system      :system
-                   :integration :integration}
+                   :integration :integration
+                   :type        :type}
   :codox          {:output-path "docs/master/current"
                    :doc-paths   ["docs/source"]
                    :metadata    {:doc/format :markdown}}

--- a/test/clojang/test/jinterface/otp/messaging_test.clj
+++ b/test/clojang/test/jinterface/otp/messaging_test.clj
@@ -1,0 +1,7 @@
+(ns clojang.test.jinterface.otp.messaging-test
+  (:require [clojure.core.typed :refer [check-ns]]
+            [clojure.test :refer [deftest is]]
+            clojang.jinterface.otp.messaging))
+
+(deftest ^:type type-annotations-test
+  (is (check-ns 'clojang.jinterface.otp.messaging)))

--- a/test/clojang/test/jinterface/otp/messaging_test.clj
+++ b/test/clojang/test/jinterface/otp/messaging_test.clj
@@ -3,5 +3,5 @@
             [clojure.test :refer [deftest is]]
             clojang.jinterface.otp.messaging))
 
-(deftest ^:type type-annotations-test
+(deftest ^:typed type-annotations-test
   (is (check-ns 'clojang.jinterface.otp.messaging)))


### PR DESCRIPTION
- Cosmetic tweaks
- Collect `ping` clauses
- Update `messaging` `ns` form
  Add `core.typed` stuff and import a few more JInterface types.
- Annotate `messaging/MsgObject` protocol
- Annotate `messaging/mbox`
- Annotate `messaging/MboxObject` protocol  
  **Caveat**: `.exit` and `.send` don't allow `String`s in place of `OtpErlangObject`s  
  I've added notes and comments where appropriate.
- Add `messaging-test` with `t/check-ns`